### PR TITLE
Updated Flink version to 1.19.1 in docker-compose and pom configurations, added Kafka connector dependency.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - flink-network
 
   flink:
-    image: flink:latest
+    image: flink:1.17.0
     hostname: flink-master
     container_name: jobmanager
     restart: on-failure
@@ -67,7 +67,7 @@ services:
     volumes:
       - /home/waqas/Projects/Flink/quickstart/jars:/opt/flink/usrlib
   flink_task_manager:
-    image: flink:latest
+    image: flink:1.17.0
     hostname: flink-worker
     container_name: taskmanager
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - flink-network
 
   flink:
-    image: flink:1.17.0
+    image: flink:1.19.1
     hostname: flink-master
     container_name: jobmanager
     restart: on-failure
@@ -66,7 +66,7 @@ services:
     volumes:
       - /home/waqas/Projects/Flink/quickstart/jars:/opt/flink/usrlib
   flink_task_manager:
-    image: flink:1.17.0
+    image: flink:1.19.1
     hostname: flink-worker
     container_name: taskmanager
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.1

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.17.0</flink.version>
+		<flink.version>1.19.1</flink.version>
+    <flink.connector.kafka.version>3.3.0-1.19</flink.connector.kafka.version>
 		<target.java.version>11</target.java.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
@@ -68,11 +69,16 @@ under the License.
 		</dependency>
 
 		<!-- Add connector dependencies here. They must be in the default scope (compile). -->
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-connector-base</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
-			<version>${flink.version}</version>
+			<version>${flink.connector.kafka.version}</version>
 		</dependency>
 
 		<!-- Add logging framework, to produce console output when running in the IDE. -->


### PR DESCRIPTION
Updated Flink version to 1.19.1 in docker-compose and pom configurations, added Kafka connector dependency.